### PR TITLE
Fix core22 snap

### DIFF
--- a/.github/workflows/snap_core22.yaml
+++ b/.github/workflows/snap_core22.yaml
@@ -11,16 +11,22 @@ jobs:
     outputs:
       snap-file: ${{ steps.build-snap22.outputs.snap }}
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         # full history for latest tag name
         fetch-depth: 0
-    - run: mv snap_core22 snap
-    - uses: snapcore/action-build@v1
+    - name: Rename snap_core22 to snap
+      run: mv snap_core22 snap
+    - name: Build Snap (Core22)
+      uses: snapcore/action-build@v1
+      with:
+        snapcraft-channel: 7.x/stable
       id: build-snap22
 
     # Make sure the snap is installable
-    - run: |
+    - name: Install snap
+      run: |
         sudo snap install --dangerous ${{ steps.build-snap22.outputs.snap }}
 
     - uses: actions/upload-artifact@v4
@@ -33,11 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/download-artifact@v4
+    - name: Download artifact
+      uses: actions/download-artifact@v4
       with:
         name: plotjuggler-snap22
         path: .
-    - uses: snapcore/action-publish@v1
+    - name: Publish snap
+      uses: snapcore/action-publish@v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:

--- a/snap_core22/snapcraft.yaml
+++ b/snap_core22/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
 issues: https://github.com/facontidavide/plotjuggler/issues
 source-code: https://github.com/facontidavide/plotjuggler
 license: MPL-2.0
-
+version: git
 confinement: strict
 base: core22
 
@@ -29,8 +29,9 @@ parts:
     plugin: cmake
     source: .
     cmake-parameters:
+      - -DBASE_AS_SHARED=ON
       - -DCMAKE_BUILD_TYPE=Release
-      - "-DCMAKE_PREFIX_PATH=$(echo $SNAPCRAFT_CMAKE_ARGS | awk -F= '{printf(\"%s/usr/lib/$CRAFT_ARCH_TRIPLET/cmake/Qt5\", $2)}')"
+      - "-DCMAKE_PREFIX_PATH=$(echo $SNAPCRAFT_CMAKE_ARGS | awk -F= '{printf(\"%s/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/cmake/Qt5\", $2)}')"
     build-packages:
       - distro-info-data
       - libpulse0
@@ -57,6 +58,11 @@ parts:
         [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
         craftctl set version="$version"
         craftctl set grade="$grade"
+
+        # Include CMakeFindDependencyMacro to make sure find_dependency is found by cmake
+        sed -i '/@PACKAGE_INIT@/a include(CMakeFindDependencyMacro)' cmake/Config.cmake.in
+        # Add namespace to Cmakelists to make sure libraries can be properly exported
+        sed -i '/FILE ${PROJECT_NAME}Targets.cmake/a\      NAMESPACE ${PROJECT_NAME}::' CMakeLists.txt
 
         # Necessary to bypass XDG desktop portals because ROS 2 bags metadata.yaml are referring db3 files relatively
         sed -i '/QApplication app(new_argc, new_argv.data());/a QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);' plotjuggler_app/main.cpp


### PR DESCRIPTION
This PR fixes the core22 snap.

The snap required some changes in the CMakelists.txt due to latest changes in the project installation settings.

The main changes are:

- Add the `NAMESPACE` keyword to the `install(EXPORT)` (when not building with ament) to properly set up namespace for exported targets (e.g. plotjuggler::plotjuggler_base) needed by the `plotjuggler-ros-plugins` package.

- Add `include(CMakeFindDependencyMacro)` in the cmake config because of find_dependency(...). Without this, the cmake pluging fails to find the macro.

This PR pins snapcraft build to 7.x/stable, to avoid failure due to snapcraft 8.x refactoring.